### PR TITLE
fix: address devalue prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "spider-solitaire",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "spider-solitaire",
-			"version": "0.0.6",
+			"version": "0.0.7",
 			"devDependencies": {
 				"@eslint/compat": "^1.4.0",
 				"@eslint/js": "^9.36.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,39 +8,26 @@
 			"name": "spider-solitaire",
 			"version": "0.0.6",
 			"devDependencies": {
-				"@eslint/compat": "^1.2.5",
-				"@eslint/js": "^9.18.0",
-				"@sveltejs/adapter-static": "^3.0.8",
-				"@sveltejs/kit": "^2.16.0",
-				"@sveltejs/vite-plugin-svelte": "^5.0.0",
-				"@tailwindcss/typography": "^0.5.15",
-				"@tailwindcss/vite": "^4.0.0",
-				"eslint": "^9.18.0",
-				"eslint-config-prettier": "^10.0.1",
-				"eslint-plugin-svelte": "^3.0.0",
-				"globals": "^16.0.0",
-				"prettier": "^3.4.2",
-				"prettier-plugin-svelte": "^3.3.3",
-				"prettier-plugin-tailwindcss": "^0.6.11",
-				"svelte": "^5.0.0",
-				"svelte-check": "^4.0.0",
-				"tailwindcss": "^4.0.0",
-				"typescript": "^5.0.0",
-				"typescript-eslint": "^8.20.0",
-				"vite": "^6.0.0"
-			}
-		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"@eslint/compat": "^1.4.0",
+				"@eslint/js": "^9.36.0",
+				"@sveltejs/adapter-static": "^3.0.9",
+				"@sveltejs/kit": "^2.43.5",
+				"@sveltejs/vite-plugin-svelte": "^5.1.1",
+				"@tailwindcss/typography": "^0.5.19",
+				"@tailwindcss/vite": "^4.1.13",
+				"eslint": "^9.36.0",
+				"eslint-config-prettier": "^10.1.8",
+				"eslint-plugin-svelte": "^3.12.4",
+				"globals": "^16.4.0",
+				"prettier": "^3.6.2",
+				"prettier-plugin-svelte": "^3.4.0",
+				"prettier-plugin-tailwindcss": "^0.6.14",
+				"svelte": "^5.39.6",
+				"svelte-check": "^4.3.2",
+				"tailwindcss": "^4.1.13",
+				"typescript": "^5.9.2",
+				"typescript-eslint": "^8.44.1",
+				"vite": "^6.3.6"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -444,9 +431,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -484,16 +471,19 @@
 			}
 		},
 		"node_modules/@eslint/compat": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.9.tgz",
-			"integrity": "sha512-gCdSY54n7k+driCadyMNv8JSPzYLeDVM/ikZRtvtROBpRdFSkS8W9A82MqsaY7lZuwL0wiapgD0NT1xT0hyJsA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.0.tgz",
+			"integrity": "sha512-DEzm5dKeDBPm3r08Ixli/0cmxr8LkRdwxMRUIJBlSCpAwSrvFEJpVBzV+66JhDxiaqKxnRzCXhtiMiczF7Hglg==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.16.0"
+			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"peerDependencies": {
-				"eslint": "^9.10.0"
+				"eslint": "^8.40 || 9"
 			},
 			"peerDependenciesMeta": {
 				"eslint": {
@@ -502,10 +492,11 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-			"integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+			"integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.6",
 				"debug": "^4.3.1",
@@ -516,19 +507,21 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
-			"integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+			"integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-			"integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+			"integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -572,13 +565,16 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.26.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
-			"integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
+			"version": "9.36.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+			"integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
 			}
 		},
 		"node_modules/@eslint/object-schema": {
@@ -586,18 +582,33 @@
 			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
 			"integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-			"integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.13.0",
+				"@eslint/core": "^0.15.2",
 				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -691,6 +702,17 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -710,10 +732,11 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-			"dev": true
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
@@ -723,28 +746,6 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
-		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.2.tgz",
-			"integrity": "sha512-H9vwztj5OAqHg9GockCQC06k1natgcxWQSRpQcPJf6i5+MWBzfKkRtxGbjQf0X2ihii0ffLZCRGbYV2f2bjNCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^1.0.5",
-				"cors": "^2.8.5",
-				"cross-spawn": "^7.0.3",
-				"eventsource": "^3.0.2",
-				"express": "^5.0.1",
-				"express-rate-limit": "^7.5.0",
-				"pkce-challenge": "^5.0.0",
-				"raw-body": "^3.0.0",
-				"zod": "^3.23.8",
-				"zod-to-json-schema": "^3.24.1"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -1051,6 +1052,13 @@
 				"win32"
 			]
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@sveltejs/acorn-typescript": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
@@ -1061,26 +1069,28 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-static": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.8.tgz",
-			"integrity": "sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.9.tgz",
+			"integrity": "sha512-aytHXcMi7lb9ljsWUzXYQ0p5X1z9oWud2olu/EpmH7aCu4m84h7QLvb5Wp+CFirKcwoNnYvYWhyP/L8Vh1ztdw==",
 			"dev": true,
+			"license": "MIT",
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0"
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.21.0.tgz",
-			"integrity": "sha512-kvu4h9qXduiPk1Q1oqFKDLFGu/7mslEYbVaqpbBcBxjlRJnvNCFwEvEwKt0Mx9TtSi8J77xRelvJobrGlst4nQ==",
+			"version": "2.43.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.43.5.tgz",
+			"integrity": "sha512-44Mm5csR4mesKx2Eyhtk8UVrLJ4c04BT2wMTfYGKJMOkUqpHP5KLL2DPV0hXUA4t4+T3ZYe0aBygd42lVYv2cA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.1.0",
+				"devalue": "^5.3.2",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -1096,23 +1106,40 @@
 				"node": ">=18.13"
 			},
 			"peerDependencies": {
-				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0",
+				"@opentelemetry/api": "^1.0.0",
+				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"vite": "^5.0.3 || ^6.0.0"
+				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@sveltejs/kit/node_modules/cookie": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.0.3.tgz",
-			"integrity": "sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+			"integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
-				"debug": "^4.4.0",
+				"debug": "^4.4.1",
 				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.30.15",
-				"vitefu": "^1.0.4"
+				"magic-string": "^0.30.17",
+				"vitefu": "^1.0.6"
 			},
 			"engines": {
 				"node": "^18.0.0 || ^20.0.0 || >=22"
@@ -1140,25 +1167,25 @@
 			}
 		},
 		"node_modules/@tailwindcss/node": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.6.tgz",
-			"integrity": "sha512-ed6zQbgmKsjsVvodAS1q1Ld2BolEuxJOSyyNc+vhkjdmfNUDCmQnlXBfQkHrlzNmslxHsQU/bFmzcEbv4xXsLg==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
+			"integrity": "sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.3.0",
-				"enhanced-resolve": "^5.18.1",
-				"jiti": "^2.4.2",
-				"lightningcss": "1.29.2",
-				"magic-string": "^0.30.17",
+				"@jridgewell/remapping": "^2.3.4",
+				"enhanced-resolve": "^5.18.3",
+				"jiti": "^2.5.1",
+				"lightningcss": "1.30.1",
+				"magic-string": "^0.30.18",
 				"source-map-js": "^1.2.1",
-				"tailwindcss": "4.1.6"
+				"tailwindcss": "4.1.13"
 			}
 		},
 		"node_modules/@tailwindcss/oxide": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.6.tgz",
-			"integrity": "sha512-0bpEBQiGx+227fW4G0fLQ8vuvyy5rsB1YIYNapTq3aRsJ9taF3f5cCaovDjN5pUGKKzcpMrZst/mhNaKAPOHOA==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.13.tgz",
+			"integrity": "sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1170,24 +1197,24 @@
 				"node": ">= 10"
 			},
 			"optionalDependencies": {
-				"@tailwindcss/oxide-android-arm64": "4.1.6",
-				"@tailwindcss/oxide-darwin-arm64": "4.1.6",
-				"@tailwindcss/oxide-darwin-x64": "4.1.6",
-				"@tailwindcss/oxide-freebsd-x64": "4.1.6",
-				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.6",
-				"@tailwindcss/oxide-linux-arm64-gnu": "4.1.6",
-				"@tailwindcss/oxide-linux-arm64-musl": "4.1.6",
-				"@tailwindcss/oxide-linux-x64-gnu": "4.1.6",
-				"@tailwindcss/oxide-linux-x64-musl": "4.1.6",
-				"@tailwindcss/oxide-wasm32-wasi": "4.1.6",
-				"@tailwindcss/oxide-win32-arm64-msvc": "4.1.6",
-				"@tailwindcss/oxide-win32-x64-msvc": "4.1.6"
+				"@tailwindcss/oxide-android-arm64": "4.1.13",
+				"@tailwindcss/oxide-darwin-arm64": "4.1.13",
+				"@tailwindcss/oxide-darwin-x64": "4.1.13",
+				"@tailwindcss/oxide-freebsd-x64": "4.1.13",
+				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.13",
+				"@tailwindcss/oxide-linux-arm64-gnu": "4.1.13",
+				"@tailwindcss/oxide-linux-arm64-musl": "4.1.13",
+				"@tailwindcss/oxide-linux-x64-gnu": "4.1.13",
+				"@tailwindcss/oxide-linux-x64-musl": "4.1.13",
+				"@tailwindcss/oxide-wasm32-wasi": "4.1.13",
+				"@tailwindcss/oxide-win32-arm64-msvc": "4.1.13",
+				"@tailwindcss/oxide-win32-x64-msvc": "4.1.13"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-android-arm64": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.6.tgz",
-			"integrity": "sha512-VHwwPiwXtdIvOvqT/0/FLH/pizTVu78FOnI9jQo64kSAikFSZT7K4pjyzoDpSMaveJTGyAKvDjuhxJxKfmvjiQ==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.13.tgz",
+			"integrity": "sha512-BrpTrVYyejbgGo57yc8ieE+D6VT9GOgnNdmh5Sac6+t0m+v+sKQevpFVpwX3pBrM2qKrQwJ0c5eDbtjouY/+ew==",
 			"cpu": [
 				"arm64"
 			],
@@ -1202,9 +1229,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-arm64": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.6.tgz",
-			"integrity": "sha512-weINOCcqv1HVBIGptNrk7c6lWgSFFiQMcCpKM4tnVi5x8OY2v1FrV76jwLukfT6pL1hyajc06tyVmZFYXoxvhQ==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.13.tgz",
+			"integrity": "sha512-YP+Jksc4U0KHcu76UhRDHq9bx4qtBftp9ShK/7UGfq0wpaP96YVnnjFnj3ZFrUAjc5iECzODl/Ts0AN7ZPOANQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1219,9 +1246,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-x64": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.6.tgz",
-			"integrity": "sha512-3FzekhHG0ww1zQjQ1lPoq0wPrAIVXAbUkWdWM8u5BnYFZgb9ja5ejBqyTgjpo5mfy0hFOoMnMuVDI+7CXhXZaQ==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.13.tgz",
+			"integrity": "sha512-aAJ3bbwrn/PQHDxCto9sxwQfT30PzyYJFG0u/BWZGeVXi5Hx6uuUOQEI2Fa43qvmUjTRQNZnGqe9t0Zntexeuw==",
 			"cpu": [
 				"x64"
 			],
@@ -1236,9 +1263,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-freebsd-x64": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.6.tgz",
-			"integrity": "sha512-4m5F5lpkBZhVQJq53oe5XgJ+aFYWdrgkMwViHjRsES3KEu2m1udR21B1I77RUqie0ZYNscFzY1v9aDssMBZ/1w==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.13.tgz",
+			"integrity": "sha512-Wt8KvASHwSXhKE/dJLCCWcTSVmBj3xhVhp/aF3RpAhGeZ3sVo7+NTfgiN8Vey/Fi8prRClDs6/f0KXPDTZE6nQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1253,9 +1280,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.6.tgz",
-			"integrity": "sha512-qU0rHnA9P/ZoaDKouU1oGPxPWzDKtIfX7eOGi5jOWJKdxieUJdVV+CxWZOpDWlYTd4N3sFQvcnVLJWJ1cLP5TA==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.13.tgz",
+			"integrity": "sha512-mbVbcAsW3Gkm2MGwA93eLtWrwajz91aXZCNSkGTx/R5eb6KpKD5q8Ueckkh9YNboU8RH7jiv+ol/I7ZyQ9H7Bw==",
 			"cpu": [
 				"arm"
 			],
@@ -1270,9 +1297,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.6.tgz",
-			"integrity": "sha512-jXy3TSTrbfgyd3UxPQeXC3wm8DAgmigzar99Km9Sf6L2OFfn/k+u3VqmpgHQw5QNfCpPe43em6Q7V76Wx7ogIQ==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.13.tgz",
+			"integrity": "sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1287,9 +1314,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.6.tgz",
-			"integrity": "sha512-8kjivE5xW0qAQ9HX9reVFmZj3t+VmljDLVRJpVBEoTR+3bKMnvC7iLcoSGNIUJGOZy1mLVq7x/gerVg0T+IsYw==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.13.tgz",
+			"integrity": "sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1304,9 +1331,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.6.tgz",
-			"integrity": "sha512-A4spQhwnWVpjWDLXnOW9PSinO2PTKJQNRmL/aIl2U/O+RARls8doDfs6R41+DAXK0ccacvRyDpR46aVQJJCoCg==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.13.tgz",
+			"integrity": "sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1321,9 +1348,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-musl": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.6.tgz",
-			"integrity": "sha512-YRee+6ZqdzgiQAHVSLfl3RYmqeeaWVCk796MhXhLQu2kJu2COHBkqlqsqKYx3p8Hmk5pGCQd2jTAoMWWFeyG2A==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.13.tgz",
+			"integrity": "sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1338,9 +1365,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.6.tgz",
-			"integrity": "sha512-qAp4ooTYrBQ5pk5jgg54/U1rCJ/9FLYOkkQ/nTE+bVMseMfB6O7J8zb19YTpWuu4UdfRf5zzOrNKfl6T64MNrQ==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.13.tgz",
+			"integrity": "sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==",
 			"bundleDependencies": [
 				"@napi-rs/wasm-runtime",
 				"@emnapi/core",
@@ -1356,11 +1383,11 @@
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "^1.4.3",
-				"@emnapi/runtime": "^1.4.3",
-				"@emnapi/wasi-threads": "^1.0.2",
-				"@napi-rs/wasm-runtime": "^0.2.9",
-				"@tybys/wasm-util": "^0.9.0",
+				"@emnapi/core": "^1.4.5",
+				"@emnapi/runtime": "^1.4.5",
+				"@emnapi/wasi-threads": "^1.0.4",
+				"@napi-rs/wasm-runtime": "^0.2.12",
+				"@tybys/wasm-util": "^0.10.0",
 				"tslib": "^2.8.0"
 			},
 			"engines": {
@@ -1368,9 +1395,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.6.tgz",
-			"integrity": "sha512-nqpDWk0Xr8ELO/nfRUDjk1pc9wDJ3ObeDdNMHLaymc4PJBWj11gdPCWZFKSK2AVKjJQC7J2EfmSmf47GN7OuLg==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.13.tgz",
+			"integrity": "sha512-dziTNeQXtoQ2KBXmrjCxsuPk3F3CQ/yb7ZNZNA+UkNTeiTGgfeh+gH5Pi7mRncVgcPD2xgHvkFCh/MhZWSgyQg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1385,9 +1412,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.6.tgz",
-			"integrity": "sha512-5k9xF33xkfKpo9wCvYcegQ21VwIBU1/qEbYlVukfEIyQbEA47uK8AAwS7NVjNE3vHzcmxMYwd0l6L4pPjjm1rQ==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.13.tgz",
+			"integrity": "sha512-3+LKesjXydTkHk5zXX01b5KMzLV1xl2mcktBJkje7rhFUpUlYJy7IMOLqjIRQncLTa1WZZiFY/foAeB5nmaiTw==",
 			"cpu": [
 				"x64"
 			],
@@ -1402,14 +1429,12 @@
 			}
 		},
 		"node_modules/@tailwindcss/typography": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
-			"integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+			"integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"lodash.castarray": "^4.4.0",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.merge": "^4.6.2",
 				"postcss-selector-parser": "6.0.10"
 			},
 			"peerDependencies": {
@@ -1417,18 +1442,18 @@
 			}
 		},
 		"node_modules/@tailwindcss/vite": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.6.tgz",
-			"integrity": "sha512-zjtqjDeY1w3g2beYQtrMAf51n5G7o+UwmyOjtsDMP7t6XyoRMOidcoKP32ps7AkNOHIXEOK0bhIC05dj8oJp4w==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.13.tgz",
+			"integrity": "sha512-0PmqLQ010N58SbMTJ7BVJ4I2xopiQn/5i6nlb4JmxzQf8zcS5+m2Cv6tqh+sfDwtIdjoEnOvwsGQ1hkUi8QEHQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tailwindcss/node": "4.1.6",
-				"@tailwindcss/oxide": "4.1.6",
-				"tailwindcss": "4.1.6"
+				"@tailwindcss/node": "4.1.13",
+				"@tailwindcss/oxide": "4.1.13",
+				"tailwindcss": "4.1.13"
 			},
 			"peerDependencies": {
-				"vite": "^5.2.0 || ^6"
+				"vite": "^5.2.0 || ^6 || ^7"
 			}
 		},
 		"node_modules/@types/cookie": {
@@ -1447,20 +1472,21 @@
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
-			"integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
+			"integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.32.1",
-				"@typescript-eslint/type-utils": "8.32.1",
-				"@typescript-eslint/utils": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1",
+				"@typescript-eslint/scope-manager": "8.44.1",
+				"@typescript-eslint/type-utils": "8.44.1",
+				"@typescript-eslint/utils": "8.44.1",
+				"@typescript-eslint/visitor-keys": "8.44.1",
 				"graphemer": "^1.4.0",
 				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
@@ -1474,15 +1500,15 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+				"@typescript-eslint/parser": "^8.44.1",
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.9.0"
+				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-			"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1490,16 +1516,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
-			"integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
+			"integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.32.1",
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/typescript-estree": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1",
+				"@typescript-eslint/scope-manager": "8.44.1",
+				"@typescript-eslint/types": "8.44.1",
+				"@typescript-eslint/typescript-estree": "8.44.1",
+				"@typescript-eslint/visitor-keys": "8.44.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1511,18 +1537,40 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.9.0"
+				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
-			"integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
+		"node_modules/@typescript-eslint/project-service": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+			"integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1"
+				"@typescript-eslint/tsconfig-utils": "^8.44.1",
+				"@typescript-eslint/types": "^8.44.1",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+			"integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.44.1",
+				"@typescript-eslint/visitor-keys": "8.44.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1532,15 +1580,33 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+			"integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
-			"integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
+			"integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.32.1",
-				"@typescript-eslint/utils": "8.32.1",
+				"@typescript-eslint/types": "8.44.1",
+				"@typescript-eslint/typescript-estree": "8.44.1",
+				"@typescript-eslint/utils": "8.44.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.1.0"
 			},
@@ -1553,13 +1619,13 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.9.0"
+				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
-			"integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+			"integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1571,14 +1637,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
-			"integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+			"integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1",
+				"@typescript-eslint/project-service": "8.44.1",
+				"@typescript-eslint/tsconfig-utils": "8.44.1",
+				"@typescript-eslint/types": "8.44.1",
+				"@typescript-eslint/visitor-keys": "8.44.1",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -1594,13 +1662,13 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.8.4 <5.9.0"
+				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1624,16 +1692,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
-			"integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+			"integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.32.1",
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/typescript-estree": "8.32.1"
+				"@typescript-eslint/scope-manager": "8.44.1",
+				"@typescript-eslint/types": "8.44.1",
+				"@typescript-eslint/typescript-estree": "8.44.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1644,18 +1712,18 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.9.0"
+				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
-			"integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+			"integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.32.1",
-				"eslint-visitor-keys": "^4.2.0"
+				"@typescript-eslint/types": "8.44.1",
+				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1665,25 +1733,12 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/accepts": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+		"node_modules/acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"mime-types": "^3.0.0",
-				"negotiator": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/acorn": {
-			"version": "8.14.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1761,27 +1816,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
-		"node_modules/body-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-			"integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "^3.1.2",
-				"content-type": "^1.0.5",
-				"debug": "^4.4.0",
-				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.6.3",
-				"on-finished": "^2.4.1",
-				"qs": "^6.14.0",
-				"raw-body": "^3.0.0",
-				"type-is": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1803,47 +1837,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/call-bound": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"get-intrinsic": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/callsites": {
@@ -1929,68 +1922,12 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
-		"node_modules/content-disposition": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-			"integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/content-type": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie-signature": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.6.0"
-			}
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -2013,10 +1950,11 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -2044,16 +1982,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/depd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/detect-libc": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2065,47 +1993,16 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
-			"integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
-			"dev": true
-		},
-		"node_modules/dunder-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.3.2.tgz",
+			"integrity": "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/encodeurl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-			"integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+			"version": "5.18.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+			"integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2114,39 +2011,6 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/es-define-property": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/esbuild": {
@@ -2189,13 +2053,6 @@
 				"@esbuild/win32-x64": "0.25.2"
 			}
 		},
-		"node_modules/escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2209,24 +2066,23 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.26.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
-			"integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
+			"version": "9.36.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+			"integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.20.0",
-				"@eslint/config-helpers": "^0.2.1",
-				"@eslint/core": "^0.13.0",
+				"@eslint/config-array": "^0.21.0",
+				"@eslint/config-helpers": "^0.3.1",
+				"@eslint/core": "^0.15.2",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.26.0",
-				"@eslint/plugin-kit": "^0.2.8",
+				"@eslint/js": "9.36.0",
+				"@eslint/plugin-kit": "^0.3.5",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
-				"@modelcontextprotocol/sdk": "^1.8.0",
 				"@types/estree": "^1.0.6",
 				"@types/json-schema": "^7.0.15",
 				"ajv": "^6.12.4",
@@ -2234,9 +2090,9 @@
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^8.3.0",
-				"eslint-visitor-keys": "^4.2.0",
-				"espree": "^10.3.0",
+				"eslint-scope": "^8.4.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
 				"esquery": "^1.5.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -2250,8 +2106,7 @@
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3",
-				"zod": "^3.24.2"
+				"optionator": "^0.9.3"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
@@ -2272,9 +2127,9 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "10.1.5",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
-			"integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+			"version": "10.1.8",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -2288,21 +2143,22 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.6.0.tgz",
-			"integrity": "sha512-IIf6Cj6yQuCwL7Qd8bX13BZspz+DQsOkClozMF9EkW20FSxI75Ndd5ZzbviCn32DdXRo9FUWXn+YMIL46qPOOg==",
+			"version": "3.12.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.12.4.tgz",
+			"integrity": "sha512-hD7wPe+vrPgx3U2X2b/wyTMtWobm660PygMGKrWWYTc9lvtY8DpNFDaU2CJQn1szLjGbn/aJ3g8WiXuKakrEkw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.1",
+				"@eslint-community/eslint-utils": "^4.6.1",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"esutils": "^2.0.3",
-				"known-css-properties": "^0.36.0",
+				"globals": "^16.0.0",
+				"known-css-properties": "^0.37.0",
 				"postcss": "^8.4.49",
 				"postcss-load-config": "^3.1.4",
 				"postcss-safe-parser": "^7.0.0",
 				"semver": "^7.6.3",
-				"svelte-eslint-parser": "^1.1.1"
+				"svelte-eslint-parser": "^1.3.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2321,10 +2177,11 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-			"integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -2337,15 +2194,29 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/@eslint/core": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/esm-env": {
@@ -2355,14 +2226,15 @@
 			"dev": true
 		},
 		"node_modules/espree": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-			"integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.14.0",
+				"acorn": "^8.15.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.2.0"
+				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2384,10 +2256,11 @@
 			}
 		},
 		"node_modules/esrap": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
-			"integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.1.0.tgz",
+			"integrity": "sha512-yzmPNpl7TBbMRC5Lj2JlJZNPml0tzqoqP5B1JXycNUwtqma9AKCO0M2wHrdgsHcy1WRW7S9rJknAMtByg3usgA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			}
@@ -2397,6 +2270,7 @@
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -2420,98 +2294,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/eventsource": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"eventsource-parser": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/eventsource-parser": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
-			"integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/express": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-			"integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "^2.0.0",
-				"body-parser": "^2.2.0",
-				"content-disposition": "^1.0.0",
-				"content-type": "^1.0.5",
-				"cookie": "^0.7.1",
-				"cookie-signature": "^1.2.1",
-				"debug": "^4.4.0",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"etag": "^1.8.1",
-				"finalhandler": "^2.1.0",
-				"fresh": "^2.0.0",
-				"http-errors": "^2.0.0",
-				"merge-descriptors": "^2.0.0",
-				"mime-types": "^3.0.0",
-				"on-finished": "^2.4.1",
-				"once": "^1.4.0",
-				"parseurl": "^1.3.3",
-				"proxy-addr": "^2.0.7",
-				"qs": "^6.14.0",
-				"range-parser": "^1.2.1",
-				"router": "^2.2.0",
-				"send": "^1.1.0",
-				"serve-static": "^2.2.0",
-				"statuses": "^2.0.1",
-				"type-is": "^2.0.1",
-				"vary": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/express-rate-limit": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-			"integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/express-rate-limit"
-			},
-			"peerDependencies": {
-				"express": "^4.11 || 5 || ^5.0.0-beta.1"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -2611,24 +2393,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/finalhandler": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-			"integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"on-finished": "^2.4.1",
-				"parseurl": "^1.3.3",
-				"statuses": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2664,26 +2428,6 @@
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true
 		},
-		"node_modules/forwarded": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/fresh": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2696,55 +2440,6 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-intrinsic": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"dunder-proto": "^1.0.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -2760,9 +2455,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "16.1.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
-			"integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
+			"version": "16.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+			"integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2770,19 +2465,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/gopd": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/graceful-fs": {
@@ -2806,62 +2488,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ignore": {
@@ -2898,23 +2524,6 @@
 				"node": ">=0.8.19"
 			}
 		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2946,13 +2555,6 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/is-promise": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -2966,13 +2568,15 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/jiti": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-			"integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
+			"integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -3026,9 +2630,9 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
-			"integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
+			"version": "0.37.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3046,10 +2650,11 @@
 			}
 		},
 		"node_modules/lightningcss": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
-			"integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+			"integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"dependencies": {
 				"detect-libc": "^2.0.3"
 			},
@@ -3061,26 +2666,27 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"optionalDependencies": {
-				"lightningcss-darwin-arm64": "1.29.2",
-				"lightningcss-darwin-x64": "1.29.2",
-				"lightningcss-freebsd-x64": "1.29.2",
-				"lightningcss-linux-arm-gnueabihf": "1.29.2",
-				"lightningcss-linux-arm64-gnu": "1.29.2",
-				"lightningcss-linux-arm64-musl": "1.29.2",
-				"lightningcss-linux-x64-gnu": "1.29.2",
-				"lightningcss-linux-x64-musl": "1.29.2",
-				"lightningcss-win32-arm64-msvc": "1.29.2",
-				"lightningcss-win32-x64-msvc": "1.29.2"
+				"lightningcss-darwin-arm64": "1.30.1",
+				"lightningcss-darwin-x64": "1.30.1",
+				"lightningcss-freebsd-x64": "1.30.1",
+				"lightningcss-linux-arm-gnueabihf": "1.30.1",
+				"lightningcss-linux-arm64-gnu": "1.30.1",
+				"lightningcss-linux-arm64-musl": "1.30.1",
+				"lightningcss-linux-x64-gnu": "1.30.1",
+				"lightningcss-linux-x64-musl": "1.30.1",
+				"lightningcss-win32-arm64-msvc": "1.30.1",
+				"lightningcss-win32-x64-msvc": "1.30.1"
 			}
 		},
 		"node_modules/lightningcss-darwin-arm64": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
-			"integrity": "sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+			"integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -3094,13 +2700,14 @@
 			}
 		},
 		"node_modules/lightningcss-darwin-x64": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.2.tgz",
-			"integrity": "sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+			"integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -3114,13 +2721,14 @@
 			}
 		},
 		"node_modules/lightningcss-freebsd-x64": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.2.tgz",
-			"integrity": "sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+			"integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -3134,13 +2742,14 @@
 			}
 		},
 		"node_modules/lightningcss-linux-arm-gnueabihf": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.2.tgz",
-			"integrity": "sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+			"integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -3154,13 +2763,14 @@
 			}
 		},
 		"node_modules/lightningcss-linux-arm64-gnu": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.2.tgz",
-			"integrity": "sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+			"integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -3174,13 +2784,14 @@
 			}
 		},
 		"node_modules/lightningcss-linux-arm64-musl": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.2.tgz",
-			"integrity": "sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+			"integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -3194,13 +2805,14 @@
 			}
 		},
 		"node_modules/lightningcss-linux-x64-gnu": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
-			"integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+			"integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -3214,13 +2826,14 @@
 			}
 		},
 		"node_modules/lightningcss-linux-x64-musl": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.2.tgz",
-			"integrity": "sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+			"integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -3234,13 +2847,14 @@
 			}
 		},
 		"node_modules/lightningcss-win32-arm64-msvc": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.2.tgz",
-			"integrity": "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+			"integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"win32"
@@ -3254,13 +2868,14 @@
 			}
 		},
 		"node_modules/lightningcss-win32-x64-msvc": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.2.tgz",
-			"integrity": "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+			"integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"win32"
@@ -3303,18 +2918,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lodash.castarray": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
-			"integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
-			"dev": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3322,45 +2925,13 @@
 			"dev": true
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.17",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+			"version": "0.30.19",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+			"integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0"
-			}
-		},
-		"node_modules/math-intrinsics": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/media-typer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/merge-descriptors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/merge2": {
@@ -3400,29 +2971,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3446,9 +2994,9 @@
 			}
 		},
 		"node_modules/minizlib": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-			"integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3456,22 +3004,6 @@
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mri": {
@@ -3521,62 +3053,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
-		},
-		"node_modules/negotiator": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/object-inspect": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/on-finished": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"wrappy": "1"
-			}
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -3637,16 +3113,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3661,18 +3127,9 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/path-to-regexp": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-			"integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=16"
+				"node": ">=8"
 			}
 		},
 		"node_modules/picocolors": {
@@ -3691,16 +3148,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pkce-challenge": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-			"integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -3814,6 +3261,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=12.0"
 			},
@@ -3844,10 +3292,11 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-			"integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -3859,25 +3308,29 @@
 			}
 		},
 		"node_modules/prettier-plugin-svelte": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
-			"integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.4.0.tgz",
+			"integrity": "sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==",
 			"dev": true,
+			"license": "MIT",
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
 			}
 		},
 		"node_modules/prettier-plugin-tailwindcss": {
-			"version": "0.6.11",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.11.tgz",
-			"integrity": "sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==",
+			"version": "0.6.14",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz",
+			"integrity": "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.21.3"
 			},
 			"peerDependencies": {
 				"@ianvs/prettier-plugin-sort-imports": "*",
+				"@prettier/plugin-hermes": "*",
+				"@prettier/plugin-oxc": "*",
 				"@prettier/plugin-pug": "*",
 				"@shopify/prettier-plugin-liquid": "*",
 				"@trivago/prettier-plugin-sort-imports": "*",
@@ -3897,6 +3350,12 @@
 			},
 			"peerDependenciesMeta": {
 				"@ianvs/prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"@prettier/plugin-hermes": {
+					"optional": true
+				},
+				"@prettier/plugin-oxc": {
 					"optional": true
 				},
 				"@prettier/plugin-pug": {
@@ -3946,20 +3405,6 @@
 				}
 			}
 		},
-		"node_modules/proxy-addr": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"forwarded": "0.2.0",
-				"ipaddr.js": "1.9.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3967,22 +3412,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -4005,32 +3434,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-			"integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.6.3",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
@@ -4104,23 +3507,6 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"node_modules/router": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"depd": "^2.0.0",
-				"is-promise": "^4.0.0",
-				"parseurl": "^1.3.3",
-				"path-to-regexp": "^8.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4157,34 +3543,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/semver": {
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -4197,63 +3555,18 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/send": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-			"integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.5",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"etag": "^1.8.1",
-				"fresh": "^2.0.0",
-				"http-errors": "^2.0.0",
-				"mime-types": "^3.0.1",
-				"ms": "^2.1.3",
-				"on-finished": "^2.4.1",
-				"range-parser": "^1.2.1",
-				"statuses": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/serve-static": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-			"integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"parseurl": "^1.3.3",
-				"send": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
 			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
 			"dev": true
 		},
-		"node_modules/setprototypeof": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -4266,84 +3579,9 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
-				"side-channel-map": "^1.0.1",
-				"side-channel-weakmap": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/side-channel-map": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.5",
-				"object-inspect": "^1.13.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/side-channel-weakmap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.5",
-				"object-inspect": "^1.13.3",
-				"side-channel-map": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/sirv": {
@@ -4367,16 +3605,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/statuses": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -4404,13 +3632,13 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.28.6",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.28.6.tgz",
-			"integrity": "sha512-9qqr7mw8YR9PAnxGFfzCK6PUlNGtns7wVavrhnxyf3fpB1mP/Ol55Z2UnIapsSzNNl3k9qw7cZ22PdE8+xT/jQ==",
+			"version": "5.39.6",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.39.6.tgz",
+			"integrity": "sha512-bOJXmuwLNaoqPCTWO8mPu/fwxI5peGE5Efe7oo6Cakpz/G60vsnVF6mxbGODaxMUFUKEnjm6XOwHEqOht6cbvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.3.0",
+				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
 				"@types/estree": "^1.0.5",
@@ -4419,7 +3647,7 @@
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
 				"esm-env": "^1.2.1",
-				"esrap": "^1.4.6",
+				"esrap": "^2.1.0",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -4430,9 +3658,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.1.7.tgz",
-			"integrity": "sha512-1jX4BzXrQJhC/Jt3SqYf6Ntu//vmfc6VWp07JkRfK2nn+22yIblspVUo96gzMkg0Zov8lQicxhxsMzOctwcMQQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.3.2.tgz",
+			"integrity": "sha512-71udP5w2kaSTcX8iV0hn3o2FWlabQHhJTJLIQrCqMsrcOeDUO2VhCQKKCA8AMVHSPwdxLEWkUWh9OKxns5PD9w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4454,10 +3682,11 @@
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.1.3.tgz",
-			"integrity": "sha512-DUc/z/vk+AFVoxGv54+BOBFqUrmUgNg2gSO2YqrE3OL6ro19/0azPmQj/4wN3s9RxuF5l7G0162q/Ddk4LJhZA==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.3.3.tgz",
+			"integrity": "sha512-oTrDR8Z7Wnguut7QH3YKh7JR19xv1seB/bz4dxU5J/86eJtZOU4eh0/jZq4dy6tAlz/KROxnkRQspv5ZEt7t+Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"eslint-scope": "^8.2.0",
 				"eslint-visitor-keys": "^4.0.0",
@@ -4486,6 +3715,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -4495,34 +3725,37 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.6.tgz",
-			"integrity": "sha512-j0cGLTreM6u4OWzBeLBpycK0WIh8w7kSwcUsQZoGLHZ7xDTdM69lN64AgoIEEwFi0tnhs4wSykUa5YWxAzgFYg==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
+			"integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
+			"integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-			"integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
+			"integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
 				"chownr": "^3.0.0",
 				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
+				"minizlib": "^3.1.0",
 				"yallist": "^5.0.0"
 			},
 			"engines": {
@@ -4556,16 +3789,6 @@
 			},
 			"engines": {
 				"node": ">=8.0"
-			}
-		},
-		"node_modules/toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6"
 			}
 		},
 		"node_modules/totalist": {
@@ -4602,26 +3825,12 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/type-is": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^1.0.5",
-				"media-typer": "^1.1.0",
-				"mime-types": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/typescript": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4631,15 +3840,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
-			"integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.1.tgz",
+			"integrity": "sha512-0ws8uWGrUVTjEeN2OM4K1pLKHK/4NiNP/vz6ns+LjT/6sqpaYzIVFajZb1fj/IDwpsrrHb3Jy0Qm5u9CPcKaeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.32.1",
-				"@typescript-eslint/parser": "8.32.1",
-				"@typescript-eslint/utils": "8.32.1"
+				"@typescript-eslint/eslint-plugin": "8.44.1",
+				"@typescript-eslint/parser": "8.44.1",
+				"@typescript-eslint/typescript-estree": "8.44.1",
+				"@typescript-eslint/utils": "8.44.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4650,17 +3860,7 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.9.0"
-			}
-		},
-		"node_modules/unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
+				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/uri-js": {
@@ -4678,20 +3878,10 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
 		},
-		"node_modules/vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/vite": {
-			"version": "6.3.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-			"integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+			"version": "6.3.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+			"integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4782,6 +3972,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -4800,13 +3991,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/yallist": {
 			"version": "5.0.0",
@@ -4849,26 +4033,6 @@
 			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
 			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
 			"dev": true
-		},
-		"node_modules/zod": {
-			"version": "3.24.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-			"integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.24.5",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-			"integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-			"dev": true,
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.24.1"
-			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,30 +14,25 @@
 		"lint": "prettier --check . && eslint ."
 	},
 	"devDependencies": {
-		"@eslint/compat": "^1.2.5",
-		"@eslint/js": "^9.18.0",
-		"@sveltejs/adapter-static": "^3.0.8",
-		"@sveltejs/kit": "^2.16.0",
-		"@sveltejs/vite-plugin-svelte": "^5.0.0",
-		"@tailwindcss/typography": "^0.5.15",
-		"@tailwindcss/vite": "^4.0.0",
-		"eslint": "^9.18.0",
-		"eslint-config-prettier": "^10.0.1",
-		"eslint-plugin-svelte": "^3.0.0",
-		"globals": "^16.0.0",
-		"prettier": "^3.4.2",
-		"prettier-plugin-svelte": "^3.3.3",
-		"prettier-plugin-tailwindcss": "^0.6.11",
-		"svelte": "^5.0.0",
-		"svelte-check": "^4.0.0",
-		"tailwindcss": "^4.0.0",
-		"typescript": "^5.0.0",
-		"typescript-eslint": "^8.20.0",
-		"vite": "^6.0.0"
-	},
-	"overrides": {
-		"@sveltejs/kit": {
-			"cookie": "^0.7.0"
-		}
+		"@eslint/compat": "^1.4.0",
+		"@eslint/js": "^9.36.0",
+		"@sveltejs/adapter-static": "^3.0.9",
+		"@sveltejs/kit": "^2.43.5",
+		"@sveltejs/vite-plugin-svelte": "^5.1.1",
+		"@tailwindcss/typography": "^0.5.19",
+		"@tailwindcss/vite": "^4.1.13",
+		"eslint": "^9.36.0",
+		"eslint-config-prettier": "^10.1.8",
+		"eslint-plugin-svelte": "^3.12.4",
+		"globals": "^16.4.0",
+		"prettier": "^3.6.2",
+		"prettier-plugin-svelte": "^3.4.0",
+		"prettier-plugin-tailwindcss": "^0.6.14",
+		"svelte": "^5.39.6",
+		"svelte-check": "^4.3.2",
+		"tailwindcss": "^4.1.13",
+		"typescript": "^5.9.2",
+		"typescript-eslint": "^8.44.1",
+		"vite": "^6.3.6"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "spider-solitaire",
 	"private": true,
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
Bumps the version of all dependencies to their latest version to address the 'devalue prototype pollution vulnerability'.