### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build_site:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/farnghwai/spider-solitaire/security/code-scanning/1](https://github.com/farnghwai/spider-solitaire/security/code-scanning/1)

In general, the problem is fixed by explicitly setting a `permissions` block so that the GITHUB_TOKEN is restricted to only what the workflow needs. You can add this at the top level of the workflow (applying to all jobs that don’t override it) and/or per job. Here, the `deploy` job already has a `permissions` block with `pages: write` and `id-token: write`, which is appropriate, but the `build_site` job has no such block.

The best minimal fix without changing existing functionality is to add a `permissions` block with `contents: read` to the `build_site` job, since it only needs to read the repository contents to build the site and upload the artifact. No extra permissions appear to be needed for this job. We do not need to touch the existing `deploy` job permissions.

Concretely:
- Edit `.github/workflows/deploy.yml`.
- Under `build_site:` (around line 8), add a `permissions:` section before `runs-on: ubuntu-latest`.
- Set `contents: read` within that block.
No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
