### PR TITLE
Security Update: Upgrade Svelte and related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"devDependencies": {
 				"@eslint/compat": "^2.0.1",
 				"@eslint/js": "^9.36.0",
-				"@sveltejs/adapter-static": "^3.0.9",
-				"@sveltejs/kit": "^2.43.5",
+				"@sveltejs/adapter-static": "^3.0.10",
+				"@sveltejs/kit": "^2.53.4",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@tailwindcss/typography": "^0.5.19",
 				"@tailwindcss/vite": "^4.1.13",
@@ -22,8 +22,8 @@
 				"prettier": "^3.6.2",
 				"prettier-plugin-svelte": "^3.4.0",
 				"prettier-plugin-tailwindcss": "^0.7.2",
-				"svelte": "^5.39.6",
-				"svelte-check": "^4.3.2",
+				"svelte": "^5.53.7",
+				"svelte-check": "^4.4.4",
 				"tailwindcss": "^4.1.13",
 				"typescript": "^5.9.2",
 				"typescript-eslint": "^8.44.1",
@@ -31,9 +31,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-			"integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -48,9 +48,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-			"integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
 			"cpu": [
 				"arm"
 			],
@@ -65,9 +65,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-			"integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
 			"cpu": [
 				"arm64"
 			],
@@ -82,9 +82,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-			"integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
 			"cpu": [
 				"x64"
 			],
@@ -99,9 +99,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-			"integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
 			"cpu": [
 				"arm64"
 			],
@@ -116,9 +116,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-			"integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
 			"cpu": [
 				"x64"
 			],
@@ -133,9 +133,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-			"integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
 			"cpu": [
 				"arm64"
 			],
@@ -150,9 +150,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-			"integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
 			"cpu": [
 				"x64"
 			],
@@ -167,9 +167,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-			"integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
 			"cpu": [
 				"arm"
 			],
@@ -184,9 +184,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-			"integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
 			"cpu": [
 				"arm64"
 			],
@@ -201,9 +201,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-			"integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
 			"cpu": [
 				"ia32"
 			],
@@ -218,9 +218,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-			"integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
 			"cpu": [
 				"loong64"
 			],
@@ -235,9 +235,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-			"integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -252,9 +252,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-			"integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -269,9 +269,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-			"integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -286,9 +286,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-			"integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
 			"cpu": [
 				"s390x"
 			],
@@ -303,9 +303,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-			"integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
 			"cpu": [
 				"x64"
 			],
@@ -320,9 +320,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-			"integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
 			"cpu": [
 				"arm64"
 			],
@@ -337,9 +337,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-			"integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
 			"cpu": [
 				"x64"
 			],
@@ -354,9 +354,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-			"integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
 			"cpu": [
 				"arm64"
 			],
@@ -371,9 +371,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-			"integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
 			"cpu": [
 				"x64"
 			],
@@ -388,9 +388,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-			"integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
 			"cpu": [
 				"arm64"
 			],
@@ -405,9 +405,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-			"integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
 			"cpu": [
 				"x64"
 			],
@@ -422,9 +422,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-			"integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
 			"cpu": [
 				"arm64"
 			],
@@ -439,9 +439,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-			"integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -456,9 +456,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-			"integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
 			"cpu": [
 				"x64"
 			],
@@ -515,37 +515,24 @@
 			}
 		},
 		"node_modules/@eslint/compat": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.1.tgz",
-			"integrity": "sha512-yl/JsgplclzuvGFNqwNYV4XNPhP3l62ZOP9w/47atNAdmDtIFCx6X7CSk/SlWUuBGkT4Et/5+UD+WyvX2iiIWA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.2.tgz",
+			"integrity": "sha512-pR1DoD0h3HfF675QZx0xsyrsU8q70Z/plx7880NOhS02NuWLgBCOMDL787nUeQ7EWLkxv3bPQJaarjcPQb2Dwg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.0.1"
+				"@eslint/core": "^1.1.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"peerDependencies": {
-				"eslint": "^8.40 || 9"
+				"eslint": "^8.40 || 9 || 10"
 			},
 			"peerDependenciesMeta": {
 				"eslint": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@eslint/compat/node_modules/@eslint/core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.0.1.tgz",
-			"integrity": "sha512-r18fEAj9uCk+VjzGt2thsbOmychS+4kxI14spVNibUO2vqKX7obOG+ymZljAwuPZl+S3clPGwCwTDtrdqTiY6Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@types/json-schema": "^7.0.15"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/config-array": {
@@ -576,7 +563,7 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
-		"node_modules/@eslint/core": {
+		"node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
 			"version": "0.17.0",
 			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
 			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
@@ -589,21 +576,34 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
+		"node_modules/@eslint/core": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+			"integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
+			"integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"debug": "^4.3.2",
 				"espree": "^10.0.1",
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.1",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.3",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
@@ -627,9 +627,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-			"integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+			"version": "9.39.3",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+			"integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -658,6 +658,19 @@
 			"dependencies": {
 				"@eslint/core": "^0.17.0",
 				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -773,9 +786,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
-			"integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+			"integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
 			"cpu": [
 				"arm"
 			],
@@ -787,9 +800,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
-			"integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+			"integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -801,9 +814,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
-			"integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+			"integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
 			"cpu": [
 				"arm64"
 			],
@@ -815,9 +828,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
-			"integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+			"integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
 			"cpu": [
 				"x64"
 			],
@@ -829,9 +842,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
-			"integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+			"integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
 			"cpu": [
 				"arm64"
 			],
@@ -843,9 +856,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
-			"integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+			"integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
 			"cpu": [
 				"x64"
 			],
@@ -857,9 +870,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
-			"integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+			"integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
 			"cpu": [
 				"arm"
 			],
@@ -871,9 +884,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
-			"integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+			"integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
 			"cpu": [
 				"arm"
 			],
@@ -885,9 +898,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
-			"integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+			"integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
 			"cpu": [
 				"arm64"
 			],
@@ -899,9 +912,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
-			"integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+			"integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
 			"cpu": [
 				"arm64"
 			],
@@ -913,9 +926,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
-			"integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+			"integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
 			"cpu": [
 				"loong64"
 			],
@@ -927,9 +940,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
-			"integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+			"integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
 			"cpu": [
 				"loong64"
 			],
@@ -941,9 +954,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
-			"integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+			"integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -955,9 +968,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
-			"integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+			"integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -969,9 +982,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
-			"integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+			"integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -983,9 +996,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
-			"integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+			"integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -997,9 +1010,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
-			"integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+			"integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
 			"cpu": [
 				"s390x"
 			],
@@ -1011,9 +1024,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
-			"integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+			"integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
 			"cpu": [
 				"x64"
 			],
@@ -1025,9 +1038,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
-			"integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+			"integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
 			"cpu": [
 				"x64"
 			],
@@ -1039,9 +1052,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
-			"integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+			"integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1053,9 +1066,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
-			"integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+			"integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1067,9 +1080,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
-			"integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+			"integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1081,9 +1094,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
-			"integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+			"integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1095,9 +1108,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
-			"integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+			"integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
 			"cpu": [
 				"x64"
 			],
@@ -1109,9 +1122,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
-			"integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+			"integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
 			"cpu": [
 				"x64"
 			],
@@ -1130,9 +1143,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
-			"integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
+			"integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -1150,9 +1163,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.50.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.50.0.tgz",
-			"integrity": "sha512-Hj8sR8O27p2zshFEIJzsvfhLzxga/hWw6tRLnBjMYw70m1aS9BSYCqAUtzDBjRREtX1EvLMYgaC0mYE3Hz4KWA==",
+			"version": "2.53.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.53.4.tgz",
+			"integrity": "sha512-iAIPEahFgDJJyvz8g0jP08KvqnM6JvdW8YfsygZ+pMeMvyM2zssWMltcsotETvjSZ82G3VlitgDtBIvpQSZrTA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1162,13 +1175,12 @@
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.6.2",
+				"devalue": "^5.6.3",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
 				"mrmime": "^2.0.0",
-				"sade": "^1.8.1",
-				"set-cookie-parser": "^2.6.0",
+				"set-cookie-parser": "^3.0.0",
 				"sirv": "^3.0.0"
 			},
 			"bin": {
@@ -1179,10 +1191,10 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0",
-				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
+				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
 				"typescript": "^5.3.3",
-				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
@@ -1234,49 +1246,49 @@
 			}
 		},
 		"node_modules/@tailwindcss/node": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
-			"integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
+			"integrity": "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/remapping": "^2.3.4",
-				"enhanced-resolve": "^5.18.3",
+				"@jridgewell/remapping": "^2.3.5",
+				"enhanced-resolve": "^5.19.0",
 				"jiti": "^2.6.1",
-				"lightningcss": "1.30.2",
+				"lightningcss": "1.31.1",
 				"magic-string": "^0.30.21",
 				"source-map-js": "^1.2.1",
-				"tailwindcss": "4.1.18"
+				"tailwindcss": "4.2.1"
 			}
 		},
 		"node_modules/@tailwindcss/oxide": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
-			"integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.1.tgz",
+			"integrity": "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			},
 			"optionalDependencies": {
-				"@tailwindcss/oxide-android-arm64": "4.1.18",
-				"@tailwindcss/oxide-darwin-arm64": "4.1.18",
-				"@tailwindcss/oxide-darwin-x64": "4.1.18",
-				"@tailwindcss/oxide-freebsd-x64": "4.1.18",
-				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
-				"@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
-				"@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
-				"@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
-				"@tailwindcss/oxide-linux-x64-musl": "4.1.18",
-				"@tailwindcss/oxide-wasm32-wasi": "4.1.18",
-				"@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
-				"@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+				"@tailwindcss/oxide-android-arm64": "4.2.1",
+				"@tailwindcss/oxide-darwin-arm64": "4.2.1",
+				"@tailwindcss/oxide-darwin-x64": "4.2.1",
+				"@tailwindcss/oxide-freebsd-x64": "4.2.1",
+				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1",
+				"@tailwindcss/oxide-linux-arm64-gnu": "4.2.1",
+				"@tailwindcss/oxide-linux-arm64-musl": "4.2.1",
+				"@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
+				"@tailwindcss/oxide-linux-x64-musl": "4.2.1",
+				"@tailwindcss/oxide-wasm32-wasi": "4.2.1",
+				"@tailwindcss/oxide-win32-arm64-msvc": "4.2.1",
+				"@tailwindcss/oxide-win32-x64-msvc": "4.2.1"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-android-arm64": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-			"integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz",
+			"integrity": "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1287,13 +1299,13 @@
 				"android"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-arm64": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
-			"integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz",
+			"integrity": "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1304,13 +1316,13 @@
 				"darwin"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-x64": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-			"integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz",
+			"integrity": "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==",
 			"cpu": [
 				"x64"
 			],
@@ -1321,13 +1333,13 @@
 				"darwin"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-freebsd-x64": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-			"integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz",
+			"integrity": "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==",
 			"cpu": [
 				"x64"
 			],
@@ -1338,13 +1350,13 @@
 				"freebsd"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-			"integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz",
+			"integrity": "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==",
 			"cpu": [
 				"arm"
 			],
@@ -1355,13 +1367,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-			"integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz",
+			"integrity": "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1372,13 +1384,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-			"integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz",
+			"integrity": "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1389,13 +1401,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-			"integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz",
+			"integrity": "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==",
 			"cpu": [
 				"x64"
 			],
@@ -1406,13 +1418,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-musl": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-			"integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz",
+			"integrity": "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==",
 			"cpu": [
 				"x64"
 			],
@@ -1423,13 +1435,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-			"integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz",
+			"integrity": "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==",
 			"bundleDependencies": [
 				"@napi-rs/wasm-runtime",
 				"@emnapi/core",
@@ -1445,21 +1457,21 @@
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1",
+				"@emnapi/core": "^1.8.1",
+				"@emnapi/runtime": "^1.8.1",
 				"@emnapi/wasi-threads": "^1.1.0",
-				"@napi-rs/wasm-runtime": "^1.1.0",
+				"@napi-rs/wasm-runtime": "^1.1.1",
 				"@tybys/wasm-util": "^0.10.1",
-				"tslib": "^2.4.0"
+				"tslib": "^2.8.1"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-			"integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
+			"integrity": "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1470,13 +1482,13 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
-			"integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz",
+			"integrity": "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1487,7 +1499,7 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/typography": {
@@ -1504,15 +1516,15 @@
 			}
 		},
 		"node_modules/@tailwindcss/vite": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
-			"integrity": "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.1.tgz",
+			"integrity": "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tailwindcss/node": "4.1.18",
-				"@tailwindcss/oxide": "4.1.18",
-				"tailwindcss": "4.1.18"
+				"@tailwindcss/node": "4.2.1",
+				"@tailwindcss/oxide": "4.2.1",
+				"tailwindcss": "4.2.1"
 			},
 			"peerDependencies": {
 				"vite": "^5.2.0 || ^6 || ^7"
@@ -1539,18 +1551,25 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.0.tgz",
-			"integrity": "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+			"integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.53.0",
-				"@typescript-eslint/type-utils": "8.53.0",
-				"@typescript-eslint/utils": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0",
+				"@typescript-eslint/scope-manager": "8.56.1",
+				"@typescript-eslint/type-utils": "8.56.1",
+				"@typescript-eslint/utils": "8.56.1",
+				"@typescript-eslint/visitor-keys": "8.56.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.4.0"
@@ -1563,8 +1582,8 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.53.0",
-				"eslint": "^8.57.0 || ^9.0.0",
+				"@typescript-eslint/parser": "^8.56.1",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
@@ -1579,17 +1598,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.0.tgz",
-			"integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+			"integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.53.0",
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0",
+				"@typescript-eslint/scope-manager": "8.56.1",
+				"@typescript-eslint/types": "8.56.1",
+				"@typescript-eslint/typescript-estree": "8.56.1",
+				"@typescript-eslint/visitor-keys": "8.56.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1600,19 +1619,19 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.0.tgz",
-			"integrity": "sha512-Bl6Gdr7NqkqIP5yP9z1JU///Nmes4Eose6L1HwpuVHwScgDPPuEWbUVhvlZmb8hy0vX9syLk5EGNL700WcBlbg==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+			"integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.53.0",
-				"@typescript-eslint/types": "^8.53.0",
+				"@typescript-eslint/tsconfig-utils": "^8.56.1",
+				"@typescript-eslint/types": "^8.56.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1627,14 +1646,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.0.tgz",
-			"integrity": "sha512-kWNj3l01eOGSdVBnfAF2K1BTh06WS0Yet6JUgb9Cmkqaz3Jlu0fdVUjj9UI8gPidBWSMqDIglmEXifSgDT/D0g==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+			"integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0"
+				"@typescript-eslint/types": "8.56.1",
+				"@typescript-eslint/visitor-keys": "8.56.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1645,9 +1664,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.0.tgz",
-			"integrity": "sha512-K6Sc0R5GIG6dNoPdOooQ+KtvT5KCKAvTcY8h2rIuul19vxH5OTQk7ArKkd4yTzkw66WnNY0kPPzzcmWA+XRmiA==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+			"integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1662,15 +1681,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.0.tgz",
-			"integrity": "sha512-BBAUhlx7g4SmcLhn8cnbxoxtmS7hcq39xKCgiutL3oNx1TaIp+cny51s8ewnKMpVUKQUGb41RAUWZ9kxYdovuw==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+			"integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0",
-				"@typescript-eslint/utils": "8.53.0",
+				"@typescript-eslint/types": "8.56.1",
+				"@typescript-eslint/typescript-estree": "8.56.1",
+				"@typescript-eslint/utils": "8.56.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.4.0"
 			},
@@ -1682,14 +1701,14 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
-			"integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+			"integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1701,18 +1720,18 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.0.tgz",
-			"integrity": "sha512-pw0c0Gdo7Z4xOG987u3nJ8akL9093yEEKv8QTJ+Bhkghj1xyj8cgPaavlr9rq8h7+s6plUJ4QJYw2gCZodqmGw==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+			"integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.53.0",
-				"@typescript-eslint/tsconfig-utils": "8.53.0",
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0",
+				"@typescript-eslint/project-service": "8.56.1",
+				"@typescript-eslint/tsconfig-utils": "8.56.1",
+				"@typescript-eslint/types": "8.56.1",
+				"@typescript-eslint/visitor-keys": "8.56.1",
 				"debug": "^4.4.3",
-				"minimatch": "^9.0.5",
+				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
 				"tinyglobby": "^0.2.15",
 				"ts-api-utils": "^2.4.0"
@@ -1728,43 +1747,56 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.0.tgz",
-			"integrity": "sha512-XDY4mXTez3Z1iRDI5mbRhH4DFSt46oaIFsLg+Zn97+sYrXACziXSQcSelMybnVZ5pa1P6xYkPr5cMJyunM1ZDA==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+			"integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.53.0",
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0"
+				"@typescript-eslint/scope-manager": "8.56.1",
+				"@typescript-eslint/types": "8.56.1",
+				"@typescript-eslint/typescript-estree": "8.56.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1774,19 +1806,19 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.0.tgz",
-			"integrity": "sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+			"integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.0",
-				"eslint-visitor-keys": "^4.2.1"
+				"@typescript-eslint/types": "8.56.1",
+				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1796,10 +1828,23 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1821,9 +1866,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1861,9 +1906,9 @@
 			"license": "Python-2.0"
 		},
 		"node_modules/aria-query": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+			"integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1979,9 +2024,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2062,30 +2107,30 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-			"integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+			"version": "5.6.3",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
+			"integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.4",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-			"integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+			"integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.0"
 			},
 			"engines": {
 				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-			"integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -2096,32 +2141,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.2",
-				"@esbuild/android-arm": "0.27.2",
-				"@esbuild/android-arm64": "0.27.2",
-				"@esbuild/android-x64": "0.27.2",
-				"@esbuild/darwin-arm64": "0.27.2",
-				"@esbuild/darwin-x64": "0.27.2",
-				"@esbuild/freebsd-arm64": "0.27.2",
-				"@esbuild/freebsd-x64": "0.27.2",
-				"@esbuild/linux-arm": "0.27.2",
-				"@esbuild/linux-arm64": "0.27.2",
-				"@esbuild/linux-ia32": "0.27.2",
-				"@esbuild/linux-loong64": "0.27.2",
-				"@esbuild/linux-mips64el": "0.27.2",
-				"@esbuild/linux-ppc64": "0.27.2",
-				"@esbuild/linux-riscv64": "0.27.2",
-				"@esbuild/linux-s390x": "0.27.2",
-				"@esbuild/linux-x64": "0.27.2",
-				"@esbuild/netbsd-arm64": "0.27.2",
-				"@esbuild/netbsd-x64": "0.27.2",
-				"@esbuild/openbsd-arm64": "0.27.2",
-				"@esbuild/openbsd-x64": "0.27.2",
-				"@esbuild/openharmony-arm64": "0.27.2",
-				"@esbuild/sunos-x64": "0.27.2",
-				"@esbuild/win32-arm64": "0.27.2",
-				"@esbuild/win32-ia32": "0.27.2",
-				"@esbuild/win32-x64": "0.27.2"
+				"@esbuild/aix-ppc64": "0.27.3",
+				"@esbuild/android-arm": "0.27.3",
+				"@esbuild/android-arm64": "0.27.3",
+				"@esbuild/android-x64": "0.27.3",
+				"@esbuild/darwin-arm64": "0.27.3",
+				"@esbuild/darwin-x64": "0.27.3",
+				"@esbuild/freebsd-arm64": "0.27.3",
+				"@esbuild/freebsd-x64": "0.27.3",
+				"@esbuild/linux-arm": "0.27.3",
+				"@esbuild/linux-arm64": "0.27.3",
+				"@esbuild/linux-ia32": "0.27.3",
+				"@esbuild/linux-loong64": "0.27.3",
+				"@esbuild/linux-mips64el": "0.27.3",
+				"@esbuild/linux-ppc64": "0.27.3",
+				"@esbuild/linux-riscv64": "0.27.3",
+				"@esbuild/linux-s390x": "0.27.3",
+				"@esbuild/linux-x64": "0.27.3",
+				"@esbuild/netbsd-arm64": "0.27.3",
+				"@esbuild/netbsd-x64": "0.27.3",
+				"@esbuild/openbsd-arm64": "0.27.3",
+				"@esbuild/openbsd-x64": "0.27.3",
+				"@esbuild/openharmony-arm64": "0.27.3",
+				"@esbuild/sunos-x64": "0.27.3",
+				"@esbuild/win32-arm64": "0.27.3",
+				"@esbuild/win32-ia32": "0.27.3",
+				"@esbuild/win32-x64": "0.27.3"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2138,9 +2183,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+			"version": "9.39.3",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+			"integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -2151,7 +2196,7 @@
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.39.2",
+				"@eslint/js": "9.39.3",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
@@ -2215,9 +2260,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.14.0.tgz",
-			"integrity": "sha512-Isw0GvaMm0yHxAj71edAdGFh28ufYs+6rk2KlbbZphnqZAzrH3Se3t12IFh2H9+1F/jlDhBBL4oiOJmLqmYX0g==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.15.0.tgz",
+			"integrity": "sha512-QKB7zqfuB8aChOfBTComgDptMf2yxiJx7FE04nneCmtQzgTHvY8UJkuh8J2Rz7KB9FFV9aTHX6r7rdYGvG8T9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2239,7 +2284,7 @@
 				"url": "https://github.com/sponsors/ota-meshi"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.1 || ^9.0.0",
+				"eslint": "^8.57.1 || ^9.0.0 || ^10.0.0",
 				"svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -2291,6 +2336,19 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/@eslint/core": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -2330,9 +2388,9 @@
 			}
 		},
 		"node_modules/esrap": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.1.tgz",
-			"integrity": "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
+			"integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2456,9 +2514,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+			"integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -2491,9 +2549,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-17.0.0.tgz",
-			"integrity": "sha512-gv5BeD2EssA793rlFWVPMMCqefTlpusw6/2TbAVMy0FzcG8wKJn4O+NqJ4+XWmmwrayJgw5TzrmWjFgmz1XPqw==",
+			"version": "17.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+			"integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2683,9 +2741,9 @@
 			}
 		},
 		"node_modules/lightningcss": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-			"integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
+			"integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"dependencies": {
@@ -2699,23 +2757,23 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"optionalDependencies": {
-				"lightningcss-android-arm64": "1.30.2",
-				"lightningcss-darwin-arm64": "1.30.2",
-				"lightningcss-darwin-x64": "1.30.2",
-				"lightningcss-freebsd-x64": "1.30.2",
-				"lightningcss-linux-arm-gnueabihf": "1.30.2",
-				"lightningcss-linux-arm64-gnu": "1.30.2",
-				"lightningcss-linux-arm64-musl": "1.30.2",
-				"lightningcss-linux-x64-gnu": "1.30.2",
-				"lightningcss-linux-x64-musl": "1.30.2",
-				"lightningcss-win32-arm64-msvc": "1.30.2",
-				"lightningcss-win32-x64-msvc": "1.30.2"
+				"lightningcss-android-arm64": "1.31.1",
+				"lightningcss-darwin-arm64": "1.31.1",
+				"lightningcss-darwin-x64": "1.31.1",
+				"lightningcss-freebsd-x64": "1.31.1",
+				"lightningcss-linux-arm-gnueabihf": "1.31.1",
+				"lightningcss-linux-arm64-gnu": "1.31.1",
+				"lightningcss-linux-arm64-musl": "1.31.1",
+				"lightningcss-linux-x64-gnu": "1.31.1",
+				"lightningcss-linux-x64-musl": "1.31.1",
+				"lightningcss-win32-arm64-msvc": "1.31.1",
+				"lightningcss-win32-x64-msvc": "1.31.1"
 			}
 		},
 		"node_modules/lightningcss-android-arm64": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-			"integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
+			"integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2734,9 +2792,9 @@
 			}
 		},
 		"node_modules/lightningcss-darwin-arm64": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-			"integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
+			"integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2755,9 +2813,9 @@
 			}
 		},
 		"node_modules/lightningcss-darwin-x64": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-			"integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
+			"integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
 			"cpu": [
 				"x64"
 			],
@@ -2776,9 +2834,9 @@
 			}
 		},
 		"node_modules/lightningcss-freebsd-x64": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-			"integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
+			"integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
 			"cpu": [
 				"x64"
 			],
@@ -2797,9 +2855,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-arm-gnueabihf": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-			"integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
+			"integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
 			"cpu": [
 				"arm"
 			],
@@ -2818,9 +2876,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-arm64-gnu": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-			"integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
+			"integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2839,9 +2897,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-arm64-musl": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-			"integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
+			"integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2860,9 +2918,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-x64-gnu": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-			"integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
+			"integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
 			"cpu": [
 				"x64"
 			],
@@ -2881,9 +2939,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-x64-musl": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-			"integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
+			"integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
 			"cpu": [
 				"x64"
 			],
@@ -2902,9 +2960,9 @@
 			}
 		},
 		"node_modules/lightningcss-win32-arm64-msvc": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-			"integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
+			"integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
 			"cpu": [
 				"arm64"
 			],
@@ -2923,9 +2981,9 @@
 			}
 		},
 		"node_modules/lightningcss-win32-x64-msvc": {
-			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-			"integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
+			"integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
 			"cpu": [
 				"x64"
 			],
@@ -2994,9 +3052,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3175,9 +3233,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3323,9 +3381,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
-			"integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -3340,9 +3398,9 @@
 			}
 		},
 		"node_modules/prettier-plugin-svelte": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.4.1.tgz",
-			"integrity": "sha512-xL49LCloMoZRvSwa6IEdN2GV6cq2IqpYGstYtMT+5wmml1/dClEoI0MZR78MiVPpu6BdQFfN0/y73yO6+br5Pg==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.1.tgz",
+			"integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -3465,9 +3523,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
-			"integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3481,31 +3539,31 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.55.1",
-				"@rollup/rollup-android-arm64": "4.55.1",
-				"@rollup/rollup-darwin-arm64": "4.55.1",
-				"@rollup/rollup-darwin-x64": "4.55.1",
-				"@rollup/rollup-freebsd-arm64": "4.55.1",
-				"@rollup/rollup-freebsd-x64": "4.55.1",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
-				"@rollup/rollup-linux-arm-musleabihf": "4.55.1",
-				"@rollup/rollup-linux-arm64-gnu": "4.55.1",
-				"@rollup/rollup-linux-arm64-musl": "4.55.1",
-				"@rollup/rollup-linux-loong64-gnu": "4.55.1",
-				"@rollup/rollup-linux-loong64-musl": "4.55.1",
-				"@rollup/rollup-linux-ppc64-gnu": "4.55.1",
-				"@rollup/rollup-linux-ppc64-musl": "4.55.1",
-				"@rollup/rollup-linux-riscv64-gnu": "4.55.1",
-				"@rollup/rollup-linux-riscv64-musl": "4.55.1",
-				"@rollup/rollup-linux-s390x-gnu": "4.55.1",
-				"@rollup/rollup-linux-x64-gnu": "4.55.1",
-				"@rollup/rollup-linux-x64-musl": "4.55.1",
-				"@rollup/rollup-openbsd-x64": "4.55.1",
-				"@rollup/rollup-openharmony-arm64": "4.55.1",
-				"@rollup/rollup-win32-arm64-msvc": "4.55.1",
-				"@rollup/rollup-win32-ia32-msvc": "4.55.1",
-				"@rollup/rollup-win32-x64-gnu": "4.55.1",
-				"@rollup/rollup-win32-x64-msvc": "4.55.1",
+				"@rollup/rollup-android-arm-eabi": "4.59.0",
+				"@rollup/rollup-android-arm64": "4.59.0",
+				"@rollup/rollup-darwin-arm64": "4.59.0",
+				"@rollup/rollup-darwin-x64": "4.59.0",
+				"@rollup/rollup-freebsd-arm64": "4.59.0",
+				"@rollup/rollup-freebsd-x64": "4.59.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.59.0",
+				"@rollup/rollup-linux-arm64-musl": "4.59.0",
+				"@rollup/rollup-linux-loong64-gnu": "4.59.0",
+				"@rollup/rollup-linux-loong64-musl": "4.59.0",
+				"@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+				"@rollup/rollup-linux-ppc64-musl": "4.59.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.59.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.59.0",
+				"@rollup/rollup-linux-x64-gnu": "4.59.0",
+				"@rollup/rollup-linux-x64-musl": "4.59.0",
+				"@rollup/rollup-openbsd-x64": "4.59.0",
+				"@rollup/rollup-openharmony-arm64": "4.59.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.59.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.59.0",
+				"@rollup/rollup-win32-x64-gnu": "4.59.0",
+				"@rollup/rollup-win32-x64-msvc": "4.59.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -3523,9 +3581,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3536,9 +3594,9 @@
 			}
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-			"integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.0.1.tgz",
+			"integrity": "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3617,9 +3675,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.47.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.47.0.tgz",
-			"integrity": "sha512-LRhAvzhvb4lHLNAcAMJZ2ifUSOif8OuItF4khbssrIeitj01GjpumeeauSnCeAGnSI+X6P2R3Z7S4c5STv4iQQ==",
+			"version": "5.53.7",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.7.tgz",
+			"integrity": "sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -3628,13 +3686,14 @@
 				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
 				"@types/estree": "^1.0.5",
+				"@types/trusted-types": "^2.0.7",
 				"acorn": "^8.12.1",
-				"aria-query": "^5.3.1",
+				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.6.2",
+				"devalue": "^5.6.3",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.1",
+				"esrap": "^2.2.2",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -3645,9 +3704,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.3.5.tgz",
-			"integrity": "sha512-e4VWZETyXaKGhpkxOXP+B/d0Fp/zKViZoJmneZWe/05Y2aqSKj3YN2nLfYPJBQ87WEiY4BQCQ9hWGu9mPT1a1Q==",
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.4.tgz",
+			"integrity": "sha512-F1pGqXc710Oi/wTI4d/x7d6lgPwwfx1U6w3Q35n4xsC2e8C/yN2sM1+mWxjlMcpAfWucjlq4vPi+P4FZ8a14sQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3669,9 +3728,9 @@
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.1.tgz",
-			"integrity": "sha512-1eqkfQ93goAhjAXxZiu1SaKI9+0/sxp4JIWQwUpsz7ybehRE5L8dNuz7Iry7K22R47p5/+s9EM+38nHV2OlgXA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.6.0.tgz",
+			"integrity": "sha512-qoB1ehychT6OxEtQAqc/guSqLS20SlA53Uijl7x375s8nlUT0lb9ol/gzraEEatQwsyPTJo87s2CmKL9Xab+Uw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3680,11 +3739,12 @@
 				"espree": "^10.0.0",
 				"postcss": "^8.4.49",
 				"postcss-scss": "^4.0.9",
-				"postcss-selector-parser": "^7.0.0"
+				"postcss-selector-parser": "^7.0.0",
+				"semver": "^7.7.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0",
-				"pnpm": "10.24.0"
+				"pnpm": "10.30.3"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ota-meshi"
@@ -3713,9 +3773,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+			"integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -3803,16 +3863,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.53.0.tgz",
-			"integrity": "sha512-xHURCQNxZ1dsWn0sdOaOfCSQG0HKeqSj9OexIxrz6ypU6wHYOdX2I3D2b8s8wFSsSOYJb+6q283cLiLlkEsBYw==",
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
+			"integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.53.0",
-				"@typescript-eslint/parser": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0",
-				"@typescript-eslint/utils": "8.53.0"
+				"@typescript-eslint/eslint-plugin": "8.56.1",
+				"@typescript-eslint/parser": "8.56.1",
+				"@typescript-eslint/typescript-estree": "8.56.1",
+				"@typescript-eslint/utils": "8.56.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3822,7 +3882,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
@@ -3920,9 +3980,9 @@
 			}
 		},
 		"node_modules/vitefu": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
-			"integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.2.tgz",
+			"integrity": "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -3931,7 +3991,7 @@
 				"tests/projects/workspace/packages/*"
 			],
 			"peerDependencies": {
-				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0"
 			},
 			"peerDependenciesMeta": {
 				"vite": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 	"devDependencies": {
 		"@eslint/compat": "^2.0.1",
 		"@eslint/js": "^9.36.0",
-		"@sveltejs/adapter-static": "^3.0.9",
-		"@sveltejs/kit": "^2.43.5",
+		"@sveltejs/adapter-static": "^3.0.10",
+		"@sveltejs/kit": "^2.53.4",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.1.13",
@@ -28,16 +28,11 @@
 		"prettier": "^3.6.2",
 		"prettier-plugin-svelte": "^3.4.0",
 		"prettier-plugin-tailwindcss": "^0.7.2",
-		"svelte": "^5.39.6",
-		"svelte-check": "^4.3.2",
+		"svelte": "^5.53.7",
+		"svelte-check": "^4.4.4",
 		"tailwindcss": "^4.1.13",
 		"typescript": "^5.9.2",
 		"typescript-eslint": "^8.44.1",
 		"vite": "^7.3.1"
-	},
-	"overrides": {
-		"@sveltejs/kit": {
-			"cookie": "^0.7.0"
-		}
 	}
 }


### PR DESCRIPTION
This PR resolves several security vulnerabilities by upgrading dependencies to their secure versions as reported by GitHub Security Alerts.

### Changes:
- Upgraded `svelte` to `5.53.7` (Secure: >= 5.51.5)
- Upgraded `@sveltejs/kit` to `2.53.4` (Secure: ~> 2.52.2)
- Upgraded `devalue` to `5.6.3` (Secure: ~> 5.6.3)
- Upgraded `rollup` to `4.59.0` (Secure: ~> 4.59.0)
- Verified `minimatch` is no longer in the vulnerable 9.x range.