### PR TITLE
fix: add cookie override for @sveltejs/kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,10 @@
 		"typescript": "^5.9.2",
 		"typescript-eslint": "^8.44.1",
 		"vite": "^7.3.1"
-	}
+	},
+	"overrides": {
+		"@sveltejs/kit": {
+			"cookie": "^0.7.0"
+		}
+	}	
 }


### PR DESCRIPTION
This PR adds a cookie override for @sveltejs/kit in package.json to resolve a dependency issue.