### PR TITLE
fix: upgrade vite to 7.3.2 to resolve GHSA-p9ff-h696-f583

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"tailwindcss": "^4.1.13",
 				"typescript": "^5.9.2",
 				"typescript-eslint": "^8.44.1",
-				"vite": "^7.3.1"
+				"vite": "^7.3.2"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -3904,9 +3904,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"tailwindcss": "^4.1.13",
 		"typescript": "^5.9.2",
 		"typescript-eslint": "^8.44.1",
-		"vite": "^7.3.1"
+		"vite": "^7.3.2"
 	},
 	"overrides": {
 		"@sveltejs/kit": {


### PR DESCRIPTION
This PR updates vite to version 7.3.2 to resolve the vulnerability GHSA-p9ff-h696-f583 (Arbitrary File Read via Vite Dev Server WebSocket) while maintaining major version 7.